### PR TITLE
Revert "Use babel-preset-es2015-node6 instead of es2015"

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
-  "presets": ["es2015-node6", "stage-0", "react"],
+  "presets": ["es2015", "stage-0", "react"],
 	"compact": true,
   "plugins": ["add-module-exports", "transform-runtime"],
   "env": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "babel-plugin-transform-runtime": "^6.9.0",
     "babel-plugin-webpack-loaders": "^0.7.0",
     "babel-polyfill": "^6.9.1",
-    "babel-preset-es2015-node6": "^0.2.0",
+    "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.11.1",
     "babel-preset-react-hmre": "^1.1.1",
     "babel-preset-react-optimize": "^1.0.1",


### PR DESCRIPTION
This reverts commit bccb3d4d8a314d01e8aa0a911c55682a0e809028.

UglifyJS doesn't support ES2015 syntax so no native ES2015

See chentsulin/electron-react-boilerplate#275