### PR TITLE
Run webpack in parallel with parallel-webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,7 @@
   "description": "An experimental PopcornTime client",
   "main": "main.js",
   "scripts": {
-    "build": "npm run build-main && npm run build-renderer",
-    "build-main": "cross-env NODE_ENV=production FLAG_SUPPORT_NON_NATIVE_CODECS_FALLBACK=true FLAG_MANUAL_TORRENT_SELECTION=true node -r babel-register ./node_modules/webpack/bin/webpack --config webpack.config.electron.js --progress --profile --colors",
-    "build-renderer": "cross-env NODE_ENV=production FLAG_SUPPORT_NON_NATIVE_CODECS_FALLBACK=true FLAG_MANUAL_TORRENT_SELECTION=true node -r babel-register ./node_modules/webpack/bin/webpack --config webpack.config.production.js --progress --profile --colors",
+    "build": "cross-env NODE_ENV=production FLAG_SUPPORT_NON_NATIVE_CODECS_FALLBACK=true FLAG_MANUAL_TORRENT_SELECTION=true parallel-webpack --config=webpack.config.build.js",
     "dev": "cross-env NODE_ENV=development concurrently --kill-others \"npm run hot-server\" \"npm run start-hot\"",
     "postinstall": "node node_modules/fbjs-scripts/node/check-dev-engines.js package.json && cd app && npm i",
     "hot-server": "node -r babel-register server.js",
@@ -113,6 +111,7 @@
     "mocha": "^2.5.3",
     "node-libs-browser": "^1.0.0",
     "node-sass": "^3.8.0",
+    "parallel-webpack": "^1.5.0",
     "postcss-loader": "^0.9.1",
     "react-addons-test-utils": "^15.2.1",
     "redux-devtools": "^3.3.1",

--- a/webpack.config.build.js
+++ b/webpack.config.build.js
@@ -1,0 +1,8 @@
+require('babel-register');
+
+const electron = require('./webpack.config.electron');
+const production = require('./webpack.config.production');
+
+const jobs = [electron, production];
+
+module.exports = jobs;


### PR DESCRIPTION
This should make the scripts block in `package.json` much cleaner. No performance gain. Maybe we can move all webpack stuff to a folder. (/config/webpack/) ?