### PR TITLE
update npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,25 +4,6 @@
   "version": "0.0.5",
   "description": "An experimental PopcornTime client",
   "main": "main.js",
-  "scripts": {
-    "bench-api": "cross-env NODE_ENV=test BABEL_DISABLE_CACHE=1 mocha --bail --slow 3000 --timeout 20000 --inline-diffs --async-only --compilers js:babel-register --recursive --require ./test/setup.js test/**/*.benchmark.js",
-    "build": "cross-env NODE_ENV=production FLAG_SEASON_COMPLETE=true FLAG_MANUAL_TORRENT_SELECTION=true FLAG_MANUAL_TORRENT_SELECTION=true parallel-webpack --config=webpack.config.build.js",
-    "dev": "cross-env NODE_ENV=development FLAG_MANUAL_TORRENT_SELECTION=true FLAG_SEASON_COMPLETE=true npm run start-hot-server",
-    "lint": "eslint app test *.js",
-    "postinstall": "node -r babel-register postinstall.js",
-    "package": "npm run build && build --publish never",
-    "package-all": "npm run build && build --publish never --mac --win --linux",
-    "postinstall": "node node_modules/fbjs-scripts/node/check-dev-engines.js package.json",
-    "precommit": "npm run test",
-    "test-api": "cross-env NODE_ENV=test BABEL_DISABLE_CACHE=1 mocha --bail --slow 3000 --timeout 10000 --inline-diffs --async-only --compilers js:babel-register --recursive --require ./test/setup.js test/*.spec.js test/**/*.spec.js",
-    "test-watch": "npm test -- --watch",
-    "test-e2e": "cross-env NODE_ENV=test BABEL_DISABLE_CACHE=1 mocha --bail --slow 3000 --timeout 10000 --inline-diffs --compilers js:babel-register --require ./test/setup.js  ./test/e2e.js",
-    "test-screenshot": "cross-env API_USE_MOCK_DATA=true BABEL_DISABLE_CACHE=1 npm run build && mocha --bail --slow 3000 --timeout 20000 --inline-diffs --compilers js:babel-register --require ./test/setup.js  ./test/screenshot.e2e.js",
-    "test": "npm run lint && npm run package && npm run test-api && npm run test-e2e",
-    "start": "cross-env NODE_ENV=production electron ./",
-    "start-hot": "cross-env HOT=1 NODE_ENV=development electron -r babel-register ./main.development",
-    "start-hot-server": "node -r babel-register server.js"
-  },
   "bin": {
     "electron": "./node_modules/.bin/electron"
   },
@@ -164,5 +145,24 @@
   "devEngines": {
     "node": "6.x",
     "npm": "3.x"
+  },
+    "scripts": {
+    "bench-api": "cross-env NODE_ENV=test BABEL_DISABLE_CACHE=1 mocha --bail --slow 3000 --timeout 20000 --inline-diffs --async-only --compilers js:babel-register --recursive --require ./test/setup.js test/**/*.benchmark.js",
+    "build": "cross-env NODE_ENV=production FLAG_SEASON_COMPLETE=true FLAG_MANUAL_TORRENT_SELECTION=true FLAG_MANUAL_TORRENT_SELECTION=true parallel-webpack --config=webpack.config.build.js",
+    "dev": "cross-env NODE_ENV=development FLAG_MANUAL_TORRENT_SELECTION=true FLAG_SEASON_COMPLETE=true npm run start-hot-server",
+    "lint": "eslint app test *.js",
+    "postinstall": "node -r babel-register postinstall.js",
+    "package": "rm -rf ./release && npm run build && build --publish never",
+    "package-all": "rm -rf ./release && npm run build && build --publish never --mac --win --linux",
+    "postinstall": "node node_modules/fbjs-scripts/node/check-dev-engines.js package.json",
+    "precommit": "npm run test",
+    "test-api": "cross-env NODE_ENV=test BABEL_DISABLE_CACHE=1 mocha --bail --slow 3000 --timeout 10000 --inline-diffs --async-only --compilers js:babel-register --recursive --require ./test/setup.js test/*.spec.js test/**/*.spec.js",
+    "test-watch": "npm test -- --watch",
+    "test-e2e": "cross-env NODE_ENV=test BABEL_DISABLE_CACHE=1 mocha --bail --slow 3000 --timeout 10000 --inline-diffs --compilers js:babel-register --require ./test/setup.js  ./test/e2e.js",
+    "test-screenshot": "cross-env API_USE_MOCK_DATA=true BABEL_DISABLE_CACHE=1 npm run build && mocha --bail --slow 3000 --timeout 20000 --inline-diffs --compilers js:babel-register --require ./test/setup.js  ./test/screenshot.e2e.js",
+    "test": "npm run lint && npm run package && npm run test-api && npm run test-e2e",
+    "start": "cross-env NODE_ENV=production electron ./",
+    "start-hot": "cross-env HOT=1 NODE_ENV=development electron -r babel-register ./main.development",
+    "start-hot-server": "node -r babel-register server.js"
   }
 }


### PR DESCRIPTION
The npm scripts are now found at the bottom and both the `package` and `package-all` scripts clean the previous release dir (if any) before packaging.