### PR TITLE
electron-prebuilt -> electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "electron-builder": "^6.6.1",
     "electron-debug": "^1.0.1",
     "electron-devtools-installer": "^2.0.1",
-    "electron-prebuilt": "1.3.5",
+    "electron": "1.3.5",
     "electron-squirrel-startup": "^1.0.0",
     "eslint": "^3.5.0",
     "eslint-config-airbnb": "^11.0.0",


### PR DESCRIPTION
by the end of 2016, electron will no longer be distributed through the electron-prebuilt package. better to be ready now :smile: 

http://electron.atom.io/blog/2016/08/16/npm-install-electron