### PR TITLE
Fix/Card alignment

### DIFF
--- a/app/components/card/CardList.js
+++ b/app/components/card/CardList.js
@@ -13,19 +13,18 @@ type Props = {
   limit?: number,
   items?: Array<contentType>,
   isLoading?: boolean,
-  isFinished?: boolean,
-  justifyContent?: string
+  isFinished?: boolean
 };
 
 export default function CardList(props: Props) {
-  const { items, isLoading, isFinished, title, limit, justifyContent } = props;
+  const { items, isLoading, isFinished, title, limit } = props;
 
   return (
     <Container fluid>
       <Row data-e2e={`${title}-card-list`}>
         <Col sm="12">
           <h4 className="CardList--header">{title}</h4>
-          <div className="CardList" style={{ justifyContent }}>
+          <div className="CardList">
             {(limit ? items.filter((e, i) => i < limit) : items).map(item => (
               <Card
                 image={(item && item.images && item.images.fanart.thumb) || ''}
@@ -56,6 +55,5 @@ CardList.defaultProps = {
   limit: Infinity,
   items: [],
   isLoading: false,
-  isFinished: false,
-  justifyContent: 'space-between'
+  isFinished: false
 };

--- a/app/styles/components/CardList.scss
+++ b/app/styles/components/CardList.scss
@@ -9,10 +9,8 @@
 
 .CardList {
   display: flex;
-  justify-content: space-between;
-  align-content: space-between;
-  flex-flow: row wrap;
-  text-align: left;
+  justify-content: space-around;
+  flex-wrap: wrap;
 
   .Card {
     border: 10px solid transparent;


### PR DESCRIPTION
#### Description
Fixing card alignment when searching, using `space-around` for a better use of space, avoiding a big gap in the middle when just two in a row

Before:

<img width="796" alt="Screen Shot 2019-04-20 at 7 03 36 PM" src="https://user-images.githubusercontent.com/1194888/56460710-e46f6900-639e-11e9-83a0-8380c531e9cd.png">


After:
<img width="794" alt="Screen Shot 2019-04-20 at 6 54 33 PM" src="https://user-images.githubusercontent.com/1194888/56460635-986ff480-639d-11e9-817a-ac25b38a4d55.png">
